### PR TITLE
Use only source files relevant to homekit

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -5,7 +5,25 @@ wolfssl_THIRDPARTY_ROOT = $(wolfssl_ROOT)wolfssl-$(wolfssl_VERSION)
 INC_DIRS += $(wolfssl_ROOT) $(wolfssl_THIRDPARTY_ROOT)
 
 wolfssl_INC_DIR = $(wolfssl_THIRDPARTY_ROOT)
-wolfssl_SRC_DIR = $(wolfssl_THIRDPARTY_ROOT)/src $(wolfssl_THIRDPARTY_ROOT)/wolfcrypt/src
+# wolfssl_SRC_DIR = $(wolfssl_THIRDPARTY_ROOT)/src $(wolfssl_THIRDPARTY_ROOT)/wolfcrypt/src
+# this dedicated assignment reduces flash footprint by 8672 bytes for led example
+# also set #define NO_MD5 and #define NO_SHA in user_settings.h
+WC = $(wolfssl_THIRDPARTY_ROOT)/wolfcrypt/src
+wolfssl_SRC_FILES = $(WC)/chacha.c \
+                    $(WC)/chacha20_poly1305.c \
+                    $(WC)/curve25519.c \
+                    $(WC)/ed25519.c \
+                    $(WC)/fe_operations.c \
+                    $(WC)/ge_operations.c \
+                    $(WC)/hash.c \
+                    $(WC)/hmac.c \
+                    $(WC)/integer.c \
+                    $(WC)/misc.c \
+                    $(WC)/poly1305.c \
+                    $(WC)/random.c \
+                    $(WC)/sha256.c \
+                    $(WC)/sha512.c \
+                    $(WC)/srp.c
 
 EXTRA_CFLAGS += -DWOLFSSL_USER_SETTINGS
 

--- a/user_settings.h
+++ b/user_settings.h
@@ -22,4 +22,7 @@ static inline int hwrand_generate_block(uint8_t *buf, size_t len) {
 
 #define CUSTOM_RAND_GENERATE_BLOCK hwrand_generate_block
 
+#define NO_MD5
+#define NO_SHA
+
 #endif


### PR DESCRIPTION
reduces flash footprint by 8672 bytes. RAM usage is the same.